### PR TITLE
This change allows css classes to pass through to the div wrapper.

### DIFF
--- a/grails-app/taglib/org/groovydev/TwitterBootstrapTagLib.groovy
+++ b/grails-app/taglib/org/groovydev/TwitterBootstrapTagLib.groovy
@@ -72,13 +72,18 @@ class TwitterBootstrapTagLib {
         }
         linkTagAttrs.params = linkParams
 
+        def cssClasses = "pagination"
+        if (attrs.class) {
+            cssClasses = "pagination " + attrs.class
+        }
+
         // determine paging variables
         def steps = maxsteps > 0
         int currentstep = (offset / max) + 1
         int firststep = 1
         int laststep = Math.round(Math.ceil(total / max))
 
-        writer << '<div class="pagination"><ul>'
+        writer << "<div class=\"${cssClasses}\"><ul>"
         // display previous link when not on firststep
         if (currentstep > firststep) {
             linkParams.offset = offset - max


### PR DESCRIPTION
This extends the functionality of the original pagination taglib and
allows for the pagination-center and pagination-right (as well as other
css classes) to be applied to the ul div for the pagination block.
