### PR TITLE
Fixes resources dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Versioning
 
 History
 -------
+2.1.0.1
+	Fixed resources dependency
+	
 2.1.0
 	Upgraded Bootstrap to 2.1.0.
 	Removed grails-style scaffolding

--- a/TwitterBootstrapGrailsPlugin.groovy
+++ b/TwitterBootstrapGrailsPlugin.groovy
@@ -3,7 +3,7 @@ import org.groovydev.TwitterBootstrapTagLib
 class TwitterBootstrapGrailsPlugin {
     
     // the plugin version
-    def version = "2.1.0"
+    def version = "2.1.0.1"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.7 > *"
     // the other plugins this plugin depends on

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -15,10 +15,8 @@ grails.project.dependency.resolution = {
         grailsCentral()
     }
     plugins {
-        build(":tomcat:$grailsVersion") { export = false }
         build(":release:2.0.4") { export = false }
-        build(":hibernate:$grailsVersion") { export = false }
-        runtime ":resources:1.2-RC1"
+        runtime(":resources:1.1.6") { export = false }
     }
     dependencies {
     }


### PR DESCRIPTION
Fixes #46 and #44, the resources dependency is no longer exported and I've downgraded the version to the latest stable release. 
