### PR TITLE
Removed explicit dependency to log4j

### DIFF
--- a/grails-app/conf/BootstrapResources.groovy
+++ b/grails-app/conf/BootstrapResources.groovy
@@ -1,4 +1,4 @@
-def log = org.apache.log4j.Logger.getLogger('grails.plugins.twitterbootstrap.BootstrapResources')
+def log = org.slf4j.LoggerFactory.getLogger('grails.plugins.twitterbootstrap.BootstrapResources')
 def dev = grails.util.GrailsUtil.isDevelopmentEnv()
 
 def applicationContext = org.codehaus.groovy.grails.commons.ApplicationHolder.application.mainContext


### PR DESCRIPTION
I want to use logback instead of log4j - http://grails.org/plugin/logback . Why not remove a explicit dependency to log4j?
