### PR TITLE
Asset Pipeline Exclude Less Files From Precompiler

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -1,0 +1,8 @@
+import org.codehaus.groovy.grails.commons.ApplicationHolder
+
+eventAssetPrecompileStart = { assetConfig ->
+	def grailsApplication = ApplicationHolder.getApplication()
+	if(!grailsApplication.config.grails.assets.plugin."twitter-bootstrap".excludes || grailsApplication.config.grails.assets.plugin."twitter-bootstrap".excludes.size() == 0) {
+		grailsApplication.config.grails.assets.plugin."twitter-bootstrap".excludes = ["**/*.less"]
+	}
+}


### PR DESCRIPTION
We don't want to compile less files individually as they wont compile individually for the bootstrap source. This resolves this issue and allows the precompiler to run without error even with LESS.

Requiring a bootstrap less file works fine still within the scope of a main application css or less file...

Example application.less:

``` less
@import 'bootstrap';

h1 {
  color: white;
}
```

This file will still be able to find bootstrap and compile a final packaged less file.
