### PR TITLE
Updated bootstrap javascripts inclusion order

### DIFF
--- a/grails-app/assets/javascripts/bootstrap.js
+++ b/grails-app/assets/javascripts/bootstrap.js
@@ -5,8 +5,8 @@
 //=require bootstrap-collapse
 //=require bootstrap-dropdown
 //=require bootstrap-modal
+//=require bootstrap-tooltip
 //=require bootstrap-popover
 //=require bootstrap-scrollspy
 //=require bootstrap-tab
-//=require bootstrap-tooltip
 //=require bootstrap-transition


### PR DESCRIPTION
I've changed the bootstrap javascripts inclusion order since including popover before tooltip gives:

```
Uncaught Error: Popover requires tooltip.js
```

After changing order no error are thrown.
