### PR TITLE
removed sourceMappingURL from bootstrap.css

### DIFF
--- a/web-app/css/bootstrap.css
+++ b/web-app/css/bootstrap.css
@@ -5782,4 +5782,3 @@ button.close {
     display: none !important;
   }
 }
-/*# sourceMappingURL=bootstrap.css.map */


### PR DESCRIPTION
removed sourceMappingURL from bootstrap.css as this caused :
    "ERROR resource.ResourceMeta  - Resource not found: /bootstrap.css.map"
