### PR TITLE
Updated paginate tag to support Controller Namespace

### DIFF
--- a/grails-app/taglib/org/groovydev/TwitterBootstrapTagLib.groovy
+++ b/grails-app/taglib/org/groovydev/TwitterBootstrapTagLib.groovy
@@ -61,6 +61,9 @@ class TwitterBootstrapTagLib {
         if (params.order) linkParams.order = params.order
 
         def linkTagAttrs = [action:action]
+        if (attrs.namespace) {
+            linkTagAttrs.namespace = attrs.namespace
+        }
         if (attrs.controller) {
             linkTagAttrs.controller = attrs.controller
         }


### PR DESCRIPTION
Updated TwitterBootstrapTagLib.paginate to support building links to controllers that are namespaced
